### PR TITLE
add styles and js for focus, keyboard nav

### DIFF
--- a/dark_style.css
+++ b/dark_style.css
@@ -32,7 +32,7 @@
 .collapseall, .expandall {
 	cursor: pointer;
 }
-.collapseall:hover, .expandall:hover {
+.collapseall:hover, .expandall:hover, .collapseall:focus, .expandall:focus {
 	text-decoration: underline;
 }
 .maptastic {

--- a/js/collapse.js
+++ b/js/collapse.js
@@ -301,6 +301,14 @@ jQuery(document).ready(function() {
 		mouseleave: function(){
 			//stuff to do on mouseleave
 			jQuery(this).removeClass('colomat-hover');
+		},
+		focusin: function(){
+			//stuff to do on keyboard focus
+			jQuery(this).addClass('colomat-hover');
+		},
+		focusout: function(){
+			//stuff to do on losing keyboard focus
+			jQuery(this).removeClass('colomat-hover');
 		}
 	}, '.collapseomatic'); //pass the element as an argument to .on
 

--- a/light_style.css
+++ b/light_style.css
@@ -32,7 +32,7 @@
 .collapseall, .expandall {
 	cursor: pointer;
 }
-.collapseall:hover, .expandall:hover {
+.collapseall:hover, .expandall:hover, .collapseall:focus, .expandall:focus {
 	text-decoration: underline;
 }
 .maptastic {


### PR DESCRIPTION
I work on a US gov site that uses collapse-o-matic and needs to be sure it complies with Accessibility requirements, including keyboard navigation. Made these minor updates to the default styles and JS. Would be great if they were in your next release. Thanks for the awesome plugin
