### PR TITLE
Allow users to handle styling themselves

### DIFF
--- a/collapse-o-matic.php
+++ b/collapse-o-matic.php
@@ -136,8 +136,10 @@ class WP_Collapse_O_Matic {
 		}
 
 		//css
-		wp_register_style( 'collapseomatic-css', plugins_url('/'.$this->options['style'].'_style.css', __FILE__) , array (), '1.6' );
-		wp_enqueue_style( 'collapseomatic-css' );
+		if ($this->options['style'] !== 'none') {
+			wp_register_style( 'collapseomatic-css', plugins_url('/'.$this->options['style'].'_style.css', __FILE__) , array (), '1.6' );
+			wp_enqueue_style( 'collapseomatic-css' );
+		}
 	}
 
 	/**
@@ -451,7 +453,8 @@ class WP_Collapse_O_Matic {
 											}
 											$st_array = array(
 												__('Light', 'colomat') => 'light',
-												__('Dark', 'colomat') => 'dark'
+												__('Dark', 'colomat') => 'dark',
+												__('None', 'colomat') => 'none'
 											);
 											foreach( $st_array as $key => $value){
 												$selected = '';
@@ -462,7 +465,7 @@ class WP_Collapse_O_Matic {
 											}
 										?>
 										</select>
-										<br /><span class="description"><?php _e('Select Light for sites with lighter backgrounds. Select Dark for sites with darker backgrounds.', 'colomat'); ?></span></label>
+										<br /><span class="description"><?php _e('Select Light for sites with lighter backgrounds. Select Dark for sites with darker backgrounds. Select None to handle styling yourself.', 'colomat'); ?></span></label>
 									</td>
 								</tr>
 


### PR DESCRIPTION
This simply adds a "None" style option which doesn't load any styles. Of course, it's then incumbent upon users to handle the styling (whether that's simply integrating light_style.css or dark_style.css into their theme's stylesheet or doing something more involved).  I'm personally using this to style things myself while also getting rid of a request (since the styling is part of the theme's stylesheet).
