### PR TITLE
add 'expand' as third argument in shortcode_atts (enables filtering)

### DIFF
--- a/collapse-o-matic.php
+++ b/collapse-o-matic.php
@@ -208,7 +208,7 @@ class WP_Collapse_O_Matic {
 			'elwrapclass' => '',
 			'filter' => $options['filter_content'],
 			'tabindex' => $options['tabindex']
-		), $atts));
+		), $atts, 'expand'));
 		if(!empty($cid)){
 			$args = array(
 				'post_type'	=> 'expand-element',


### PR DESCRIPTION
shortcode_atts() merges the passed-in values and the defaults for the shortcode. It's third argument is $shortcode, which is supposed to be the slug of the shortcode. It's optional, but if it's missing then no one can filter the arguments with the "shortcode_atts_{$shortcode}" filter.

This patch just adds the third argument so I can set a bunch of defaults for the [expand] shortcode on my site. 
