### PR TITLE
Allow only limited set of values for elwraptag to fix CVE-2023-40669 vulnerability

### DIFF
--- a/collapse-o-matic.php
+++ b/collapse-o-matic.php
@@ -310,8 +310,11 @@ class WP_Collapse_O_Matic {
 			if($elwrapclass){
 				$ewclass = 'class="'.esc_attr($elwrapclass).'"';
 			}
-			$ewo = '<'. esc_attr( $elwraptag ) .' '.$ewclass.'>';
-			$ewc = '</'. esc_attr( $elwraptag ) .'>';
+			$allowed_tags = ["div", "p", "li", "ul"];
+			$elwraptag = filter_allowed_tags( $elwraptag, $allowed_tags );
+
+			$ewo = '<'. $elwraptag .' '.$ewclass.'>';
+			$ewc = '</'. $elwraptag .'>';
 		}
 
 		$eDiv = '';
@@ -917,6 +920,20 @@ class WP_Collapse_O_Matic {
 
             // $license_data->license will be either "valid" or "invalid"
             return $license_data->license;
+	}
+
+	/**
+	 * Filter $input to allow only tags from $allowed_tags array
+	 */
+	function filter_allowed_tags( $input, $allowed_tags ) {
+		$pattern = '/\A(' . implode( '|', $allowed_tags ) . ')\Z/';
+		if ( preg_match( $pattern, $input, $matches ) ) {
+			$output = $matches[0];
+		} else {
+			$output = '';
+		}
+
+		return $output;
 	}
 
 } // end class WP_Collapse_O_Matic


### PR DESCRIPTION
The patch restricts `elwraptag` possible values to a limited set of predefined HTML tag names. 
It should fix [CVE-2023-40669](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2023-40669) vulnerability as described in PoC code in [WPScan database](https://wpscan.com/vulnerability/f9e04f83-60f9-4883-81d9-8d00f3c312ca/)
The current list of allowed HTML tag names is hardcoded and very limited, should be extended or made configurable.